### PR TITLE
Modify the logic to process one line at a time

### DIFF
--- a/lib/waffle/maker.rb
+++ b/lib/waffle/maker.rb
@@ -46,7 +46,7 @@ module Waffle
       end
 
       def wafs
-        @wafs ||= Waffle::Maker::Waf.new(options[:w]).all
+        @wafs ||= Waffle::Maker::Waf.new(options[:w])
       end
     end
   end

--- a/lib/waffle/maker/waf.rb
+++ b/lib/waffle/maker/waf.rb
@@ -16,26 +16,19 @@ module Waffle
       # { raw: "2019/01/01 01:01:01\t8.8.8.8\t/users\t攻撃\t○", path: "/users" },
       # ...
       # ]
-      def all
-        readlines.each.with_object([]) do |line, o|
-          line.chomp.tap do |line|
-            o << {
-              raw: line,
-              path: line.split(/#{parse_symbol}/)[path_position]
-            }
-          end
+      def each
+        $stdin.each(chomp: true) do |line|
+          o = {
+            raw: line,
+            path: line.split(/#{parse_symbol}/)[path_position]
+          }
+          yield o
         end
       end
 
       # @override
       def parse_symbol
         ENV.fetch("IFS", "\t")
-      end
-
-      private
-
-      def readlines
-        @readlines ||= $stdin.readlines
       end
     end
   end

--- a/lib/waffle/maker/waf.rb
+++ b/lib/waffle/maker/waf.rb
@@ -16,7 +16,7 @@ module Waffle
       # { raw: "2019/01/01 01:01:01\t8.8.8.8\t/users\t攻撃\t○", path: "/users" },
       # ...
       # ]
-      def each
+      def each(&_block)
         $stdin.each(chomp: true) do |line|
           o = {
             raw: line,


### PR DESCRIPTION
In the current logic, all lines are read at once from standard input.
https://github.com/chibicco/waffle-maker/blob/fe22d2659461a76a7a66a4236d495eb85ea2b334/lib/waffle/maker/waf.rb#L38

Therefore, it requires the same amount of memory as the log file size. It is likely to run out of memory when the log volume increases 😢 

Logic that reads from the standard input line by line and processes sequentially is more elegant and smart 😎 