### PR TITLE
Add the method of specifying char encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ By passing the WAF log from the standard input, the log that matches the route i
 $ bundle exec rake waffle:filter < alert-201912.txt
 ```
 
-If the character encoding of the log is CP932, specify the encoding with the environment variable `RUBYOPT`.
+Depending on the execution environment, you may need to pre-convert the character encoding of the log.
 
 ```sh
-$ env RUBYOPT='-ECP932:CP932' bundle exec rake waffle:filter < alert-201912.txt
+$ iconv -f CP932 -t UTF-8 < alert-201912.txt | bundle exec rake waffle:filter 
 ```
 
 with options

--- a/README.md
+++ b/README.md
@@ -24,15 +24,21 @@ Or install it yourself as:
 
 ## Usage
 
-```ruby
-$ iconv -f cp932 -t utf-8 < alert-201912.txt | bundle exec rake waffle:filter
+By passing the WAF log from the standard input, the log that matches the route is written to the standard output.
+
+```sh
+$ bundle exec rake waffle:filter < alert-201912.txt
+```
+
+If the character encoding of the log is CP932, specify the encoding with the environment variable `RUBYOPT`.
+
+```sh
+$ env RUBYOPT='-ECP932:CP932' bundle exec rake waffle:filter < alert-201912.txt
 ```
 
 with options
-
-```ruby
-$ iconv -f cp932 -t utf-8 < alert-201912.txt | bundle exec rake waffle:filter -f 2 -w 2
-```
+- `-f`: Specify the column number (offset) that contains the Rails route path. default is `2`.
+- `-w`: Specify the column number (offset) that contains the path in the WAF log. default is `2`.
 
 ## Contributing
 


### PR DESCRIPTION
The character encoding of the log can be specified with the `-E` option of Ruby using the `RUBYOPT` environment variable. This allows processing without changing the character encoding in advance with the `iconv` command.

Added the method to specify the character encoding of the log to be read in the usage.