### PR TITLE
Support waf api

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "waffle/maker"
+require "waffle/maker/api"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/waffle/maker.rb
+++ b/lib/waffle/maker.rb
@@ -3,11 +3,20 @@ require "waffle/maker/version"
 require "waffle/maker/route"
 require "waffle/maker/waf"
 require "waffle/maker/matcher"
+require "waffle/maker/api"
 require "waffle/maker/railtie" if defined?(::Rails)
 
 module Waffle
   module Maker
     class Error < StandardError; end
+
+    class Config
+      class << self
+        def default_options
+          { f: 2, w: 2, silent_error: false }
+        end
+      end
+    end
 
     class Filter
       attr_reader :options
@@ -19,7 +28,7 @@ module Waffle
       end
 
       def initialize(argv)
-        (@options = default_options).tap do |options|
+        (@options = Waffle::Maker::Config.default_options).tap do |options|
           OptionParser.new { |o|
             o.banner = "Usage: #{$0}"
             o.on("-f number", "Column number that contains the rails path") { |v| options[:f] << v.to_i }
@@ -27,11 +36,6 @@ module Waffle
             o.on("--silent-error", "Hide parsing errors, default is false") { |v| options[:silent_error] << v }
           }.parse!(argv)
         end
-      end
-
-      # @override
-      def default_options
-        { f: 2, w: 2, silent_error: false }
       end
 
       def execute

--- a/lib/waffle/maker/api.rb
+++ b/lib/waffle/maker/api.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require "date"
+require "json"
+require "net/http"
+require "waffle/maker/api/base"
+require "waffle/maker/api/alert"
+require "waffle/maker/api/alert_detail"
+require "waffle/maker/api/config"
+
+module Waffle
+  module Maker
+    module Api
+      class << self
+        def configure
+          yield config
+        end
+
+        def config
+          @config ||= Config.new
+        end
+      end
+    end
+  end
+end

--- a/lib/waffle/maker/api/alert.rb
+++ b/lib/waffle/maker/api/alert.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Waffle
+  module Maker
+    module Api
+      class Alert < Base
+        API_PATH = '/api/v1/alert'
+        attr_reader :time_order, :from, :to, :ip, :marker
+
+        def initialize(time_order: nil, from: nil, to: nil, ip: nil, marker: nil)
+          @time_order = time_order
+          @from = from
+          @to = to
+          @ip = ip
+          @marker = marker
+        end
+
+        def execute
+          body_in_hash_format
+        end
+
+        def matched_with_routes
+          body_in_hash_format.tap do |body|
+            body['data'].select! { |d| Waffle::Maker::Matcher.new(d['uri'], routes).matched? }
+          end
+        end
+
+        def url
+          return @url if @url
+
+          url_string = "#{config.api_host}#{API_PATH}?host=#{config.host}&id=#{config.id}"
+          url_string = "#{url_string}&time_order=#{@time_order}" if @time_order
+          url_string = "#{url_string}&from=#{@from}" if @from
+          url_string = "#{url_string}&to=#{@to}" if @to
+          url_string = "#{url_string}&ip=#{@ip}" if @ip
+          url_string = "#{url_string}&marker=#{@marker}" if @marker
+
+          @url = URI.parse(url_string)
+        end
+      end
+    end
+  end
+end

--- a/lib/waffle/maker/api/alert_detail.rb
+++ b/lib/waffle/maker/api/alert_detail.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Waffle
+  module Maker
+    module Api
+      class AlertDetail < Base
+        API_PATH = '/api/v1/alert_detail'
+        attr_reader :log_id
+
+        def initialize(log_id: nil)
+          @log_id = log_id
+        end
+
+        def execute
+          body_in_hash_format
+        end
+
+        def url
+          @url ||= URI.parse("#{config.api_host}#{API_PATH}?host=#{config.host}&id=#{config.id}&log_id=#{log_id}")
+        end
+      end
+    end
+  end
+end

--- a/lib/waffle/maker/api/base.rb
+++ b/lib/waffle/maker/api/base.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Waffle
+  module Maker
+    module Api
+      class Base
+        FORCE_ENCODING = "UTF-8"
+        attr_accessor :url, :headers
+
+        def body_in_hash_format
+          get.then do |response|
+            JSON.parse(response.body.force_encoding(FORCE_ENCODING))
+          end
+        end
+
+        def body_in_json_format
+          get.then do |response|
+            response.body.force_encoding(FORCE_ENCODING)
+          end
+        end
+
+        def get
+          @get ||= http.get(url, headers)
+        end
+
+        def http
+          Net::HTTP.new(url.host, url.port).tap do |http|
+            http.use_ssl = (url.scheme === "https")
+          end
+        end
+
+        def url
+          raise NotImplementedError
+        end
+
+        def headers
+          @headers ||= { "Content-Type" => "application/json", 'X-Scutum-API-Key' => config.api_key }
+        end
+
+        private
+
+        def now
+          @_now ||= DateTime.now
+        end
+
+        def beginning_of_day
+          now.strftime("%Y-%m-%dT00:00:00")
+        end
+
+        def end_of_day
+          now.strftime("%Y-%m-%dT23:59:59")
+        end
+
+        def config
+          Waffle::Maker::Api.config
+        end
+
+        def routes
+          @routes ||= Waffle::Maker::Route.new(Waffle::Maker::Config.default_options[:f], true).paths
+        end
+      end
+    end
+  end
+end

--- a/lib/waffle/maker/api/config.rb
+++ b/lib/waffle/maker/api/config.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Waffle
+  module Maker
+    module Api
+      class Config
+        attr_accessor :host, :id, :api_key, :api_host
+      end
+    end
+  end
+end

--- a/lib/waffle/maker/version.rb
+++ b/lib/waffle/maker/version.rb
@@ -2,6 +2,6 @@
 
 module Waffle
   module Maker
-    VERSION = "0.1.3"
+    VERSION = "0.2.0"
   end
 end

--- a/spec/shared_contexts/config.rb
+++ b/spec/shared_contexts/config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_context :set_sample_config do
+  before do
+    Waffle::Maker::Api.configure do |config|
+      config.host = "example.com"
+      config.api_host = "https://example.jp"
+      config.id = "ABC1234"
+      config.api_key = "123123123123123123123123123123123123"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require "coveralls"
 Coveralls.wear!
 
 require "waffle/maker"
+require "waffle/maker/api"
+require "shared_contexts/config"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/waffle/maker/api/alert_detail_spec.rb
+++ b/spec/waffle/maker/api/alert_detail_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe Waffle::Maker::Api::AlertDetail do
+  include_context :set_sample_config
+
+  describe "#url" do
+    it 'log_id parameter' do
+      expect(described_class.new(log_id: '123-456-789').url.to_s)
+        .to eq('https://example.jp/api/v1/alert_detail?host=example.com&id=ABC1234&log_id=123-456-789')
+    end
+  end
+end

--- a/spec/waffle/maker/api/alert_spec.rb
+++ b/spec/waffle/maker/api/alert_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Waffle::Maker::Api::Alert do
+  include_context :set_sample_config
+
+  describe "#url" do
+    it 'date parameter' do
+      expect(described_class.new(from: '2021-01-01T12:00:00', to: '2021-01-01T13:00:00').url.to_s)
+        .to eq('https://example.jp/api/v1/alert?host=example.com&id=ABC1234&from=2021-01-01T12:00:00&to=2021-01-01T13:00:00')
+    end
+
+    it 'ip parameter' do
+      expect(described_class.new(ip: '127.0.0.1').url.to_s)
+        .to eq('https://example.jp/api/v1/alert?host=example.com&id=ABC1234&ip=127.0.0.1')
+    end
+
+    it 'time_order parameter' do
+      expect(described_class.new(time_order: 'asc').url.to_s)
+        .to eq('https://example.jp/api/v1/alert?host=example.com&id=ABC1234&time_order=asc')
+    end
+  end
+end

--- a/spec/waffle/maker/api/base_spec.rb
+++ b/spec/waffle/maker/api/base_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe Waffle::Maker::Api::Base do
+  include_context :set_sample_config
+
+  describe "#headers" do
+    it 'valid parameter' do
+      expect(described_class.new.headers)
+        .to eq({ "Content-Type" => "application/json", 'X-Scutum-API-Key' => '123123123123123123123123123123123123' })
+    end
+  end
+end

--- a/spec/waffle/maker/api/config_spec.rb
+++ b/spec/waffle/maker/api/config_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Waffle::Maker::Api::Config do
+  describe "host" do
+    it 'configure via config block' do
+      Waffle::Maker::Api.configure { |c| c.host = 'example.com' }
+      expect(Waffle::Maker::Api.config.host).to eq('example.com')
+    end
+  end
+
+  describe "id" do
+    it 'configure via config block' do
+      Waffle::Maker::Api.configure { |c| c.id = '1234567890' }
+      expect(Waffle::Maker::Api.config.id).to eq('1234567890')
+    end
+  end
+
+  describe "api_key" do
+    it 'configure via config block' do
+      Waffle::Maker::Api.configure { |c| c.api_key = '123123123123' }
+      expect(Waffle::Maker::Api.config.api_key).to eq('123123123123')
+    end
+  end
+
+  describe "api_host" do
+    it 'configure via config block' do
+      Waffle::Maker::Api.configure { |c| c.api_host = 'https://example.com' }
+      expect(Waffle::Maker::Api.config.api_host).to eq('https://example.com')
+    end
+  end
+end


### PR DESCRIPTION
**Setup**

```
Waffle::Maker::Api.configure do |config|
  config.host = "example.com"
  config.api_host = "https://example.org"
  config.id = "ABC1234"
  config.api_key = "123123123123123123123123123123"
end
```

**Execute**

```
Waffle::Maker::Api::Alert.new.matched_with_routes
```